### PR TITLE
use explicit report file path if specified

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -31,6 +31,7 @@ export interface User {
     outputType?: 'lcov' | 'coveralls' | 'coveralls+' | 'ade' | 'files',
     pathMapping?: string[],
     prefixDir?: string,
+    outputFile?: string,
 }
 
 /**
@@ -123,6 +124,9 @@ async function loadUser(path: string): Promise<User> {
     }
     if (contents['prefix-dir']) {
         user.prefixDir = contents['prefix-dir'];
+    }
+    if (contents['output-file']) {
+        user.outputFile = contents['output-file'];
     }
 
     core.debug(`User configuration: ${JSON.stringify(user)}`);

--- a/src/grcov.ts
+++ b/src/grcov.ts
@@ -40,7 +40,7 @@ export class Grcov {
 
     public async call(config: configuration.Config, archive: string): Promise<string> {
 	    const postfix = Math.random().toString(36).substring(2, 15)
-        const reportPath = path.join(os.tmpdir(), `grcov-report-${postfix}`);
+        const reportPath = config.user.outputFile ? path.resolve(config.user.outputFile) : path.join(os.tmpdir(), `grcov-report-${postfix}`);
 
         const args = this.buildArgs(config, archive, reportPath);
 


### PR DESCRIPTION
Some actions such as `codecov/codecov-action` cannot read report files in `/tmp` because the host directory is not mounted.
This patch adds a new configuration file options that specifies the path to report file, allowed to access in subsequent actions.