### PR TITLE
Fix example grcov config (ignore-dir -> ignore)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ filter: covered
 output-type: lcov
 output-file: ./lcov.info
 prefix-dir: /home/user/build/
-ignore-dir:
+ignore:
   - "/*"
   - "C:/*"
   - "../*"

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -27,7 +27,7 @@ export interface User {
     ignoreNotExisting?: boolean,
     llvm?: boolean,
     filter?: 'covered' | 'uncovered',
-    ignoreDir?: string[],
+    ignore?: string[],
     outputType?: 'lcov' | 'coveralls' | 'coveralls+' | 'ade' | 'files',
     pathMapping?: string[],
     prefixDir?: string,
@@ -113,8 +113,8 @@ async function loadUser(path: string): Promise<User> {
     if (contents['filter']) {
         user.filter = contents['filter'];
     }
-    if (contents['ignore-dir'] && Array.isArray(contents['ignore-dir'])) {
-        user.ignoreDir = contents['ignore-dir'];
+    if (contents['ignore'] && Array.isArray(contents['ignore'])) {
+        user.ignore = contents['ignore'];
     }
     if (contents['output-type']) {
         user.outputType = contents['output-type'];

--- a/src/grcov.ts
+++ b/src/grcov.ts
@@ -84,9 +84,9 @@ export class Grcov {
             args.push(config.user.filter);
         }
 
-        if (config.user.ignoreDir) {
-            for (const dir of config.user.ignoreDir) {
-                args.push('--ignore-dir');
+        if (config.user.ignore) {
+            for (const dir of config.user.ignore) {
+                args.push('--ignore');
                 args.push(dir);
             }
         }


### PR DESCRIPTION
`ignore-dir` option has been renamed to `ignore` in grcov. [See mozilla/grcov#319]