### PR TITLE
More permissive search for .gc files

### DIFF
--- a/src/coverage.ts
+++ b/src/coverage.ts
@@ -43,7 +43,7 @@ async function getCoverageFiles(root: string): Promise<string[]> {
     let patterns: string[] = [];
     for (const crate of crates) {
         const replacement = crate.replace('-', '_');
-        patterns.push(`**/${replacement}-*.gc*`);
+        patterns.push(`**/${replacement}*.gc*`);
     }
 
     return glob.sync(patterns, {


### PR DESCRIPTION
I have some bin files that are currently not being capture by actions-rs/grcov.

This wasn't a problem when I ran grcov on travis because all my bins start with my package name as a prefix, and the instructions on the grcov readme had a more permissive regex:
https://github.com/mozilla/grcov#grcov-with-travis

I think this should match their recommendation, if it seems ok to you!