### PR TITLE
Fix --output-file breakage from grcov v0.5.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ ignore-not-existing: true
 llvm: true
 filter: covered
 output-type: lcov
-output-file: ./lcov.info
+output-path: ./lcov.info
 prefix-dir: /home/user/build/
 ignore:
   - "/*"
@@ -153,5 +153,5 @@ path-mapping:
     which might not be accessible by the Docker-based Actions,
     such as [codecov](https://github.com/marketplace/actions/codecov).\
     Consider either mount it as [a Docker volume](https://help.github.com/en/articles/workflow-syntax-for-github-actions#jobsjob_idcontainervolumes)
-    or use the `output-file` option in the [config](#config)
+    or use the `output-path` option in the [config](#config)
     to store report in the path accessible by container.

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -127,6 +127,9 @@ async function loadUser(path: string): Promise<User> {
     }
     if (contents['output-path']) {
         user.outputPath = contents['output-path'];
+    } else if (contents['output-file']) {
+        console.warn("Configuration option `output-file` is deprecated; please replace it with `output-path`.\nFor more information, see https://github.com/actions-rs/grcov/issues/70.");
+        user.outputPath = contents['output-file'];
     }
 
     core.debug(`User configuration: ${JSON.stringify(user)}`);

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -31,7 +31,7 @@ export interface User {
     outputType?: 'lcov' | 'coveralls' | 'coveralls+' | 'ade' | 'files',
     pathMapping?: string[],
     prefixDir?: string,
-    outputFile?: string,
+    outputPath?: string,
 }
 
 /**
@@ -125,8 +125,8 @@ async function loadUser(path: string): Promise<User> {
     if (contents['prefix-dir']) {
         user.prefixDir = contents['prefix-dir'];
     }
-    if (contents['output-file']) {
-        user.outputFile = contents['output-file'];
+    if (contents['output-path']) {
+        user.outputPath = contents['output-path'];
     }
 
     core.debug(`User configuration: ${JSON.stringify(user)}`);

--- a/src/grcov.ts
+++ b/src/grcov.ts
@@ -98,7 +98,7 @@ export class Grcov {
             }
         }
 
-        args.push('--output-file');
+        args.push('--output-path');
         args.push(toFile);
 
         if (config.user.outputType) {

--- a/src/grcov.ts
+++ b/src/grcov.ts
@@ -40,7 +40,7 @@ export class Grcov {
 
     public async call(config: configuration.Config, archive: string): Promise<string> {
 	    const postfix = Math.random().toString(36).substring(2, 15)
-        const reportPath = config.user.outputFile ? path.resolve(config.user.outputFile) : path.join(os.tmpdir(), `grcov-report-${postfix}`);
+        const reportPath = config.user.outputPath ? path.resolve(config.user.outputPath) : path.join(os.tmpdir(), `grcov-report-${postfix}`);
 
         const args = this.buildArgs(config, archive, reportPath);
 


### PR DESCRIPTION
Closes #70.

Now, scan for both `output-file` and `output-path`; treat them the same, but for `output-file` print a deprecation warning.  Also, update the command-line argument passed to `grcov`, and the documentation.

Is a deprecation notice needed?  Also, should I include the updated `dist/index.js` file?