### PR TITLE
Replaces report with output-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ jobs:
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-        path-to-lcov: ${{ steps.coverage.outputs.report }}
+        path-to-lcov: ${{ steps.coverage.outputs.output-path }}
     ```
 
 ## Inputs


### PR DESCRIPTION
Hi @svartalf 

i've replaced `report` with `output-path` which is the new exported parameter for the coverage path

Thanks :)