### PR TITLE
Ability to add exclusions to grcov

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ ignore:
 path-mapping:
   - "/path1"
   - "/path2"
+excl-br-line: "#\[(derive(.*)\]"
+excl-br-start: "#\[test\]"
+excl-br-stop: "cov:excl-br-stop"
+excl-line: "cov:excl-line"
+excl-start: "mod test"
+excl-stop: "cov:excl-stop"
 ```
 
 ## Notes

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -32,12 +32,12 @@ export interface User {
     pathMapping?: string[],
     prefixDir?: string,
     outputPath?: string,
-    excl_br_line?: string,
-    excl_br_start?: string,
-    excl_br_stop?: string,
-    excl_line?: string,
-    excl_start?: string,
-    excl_stop?: string,
+    exclBrLine?: string,
+    exclBrStart?: string,
+    exclBrStop?: string,
+    exclLine?: string,
+    exclStart?: string,
+    exclStop?: string,
 }
 
 /**
@@ -132,22 +132,22 @@ async function loadUser(path: string): Promise<User> {
         user.prefixDir = contents['prefix-dir'];
     }
     if (contents['excl-br-line']) {
-        user.excl_br_line = contents['excl-br-line'];
+        user.exclBrLine = contents['excl-br-line'];
     }
     if (contents['excl-br-start']) {
-        user.excl_br_start = contents['excl-br-start'];
+        user.exclBrStart = contents['excl-br-start'];
     }
     if (contents['excl-br-stop']) {
-        user.excl_br_stop = contents['excl-br-stop'];
+        user.exclBrStop = contents['excl-br-stop'];
     }
     if (contents['excl-line']) {
-        user.excl_line = contents['excl-line'];
+        user.exclLine = contents['excl-line'];
     }
     if (contents['excl-start']) {
-        user.excl_start = contents['excl-start'];
+        user.exclStart = contents['excl-start'];
     }
     if (contents['excl-stop']) {
-        user.excl_stop = contents['excl-stop'];
+        user.exclStop = contents['excl-stop'];
     }
     if (contents['output-path']) {
         user.outputPath = contents['output-path'];

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -32,6 +32,12 @@ export interface User {
     pathMapping?: string[],
     prefixDir?: string,
     outputPath?: string,
+    excl_br_line?: string,
+    excl_br_start?: string,
+    excl_br_stop?: string,
+    excl_line?: string,
+    excl_start?: string,
+    excl_stop?: string,
 }
 
 /**
@@ -124,6 +130,24 @@ async function loadUser(path: string): Promise<User> {
     }
     if (contents['prefix-dir']) {
         user.prefixDir = contents['prefix-dir'];
+    }
+    if (contents['excl-br-line']) {
+        user.excl_br_line = contents['excl-br-line'];
+    }
+    if (contents['excl-br-start']) {
+        user.excl_br_start = contents['excl-br-start'];
+    }
+    if (contents['excl-br-stop']) {
+        user.excl_br_stop = contents['excl-br-stop'];
+    }
+    if (contents['excl-line']) {
+        user.excl_line = contents['excl-line'];
+    }
+    if (contents['excl-start']) {
+        user.excl_start = contents['excl-start'];
+    }
+    if (contents['excl-stop']) {
+        user.excl_stop = contents['excl-stop'];
     }
     if (contents['output-path']) {
         user.outputPath = contents['output-path'];

--- a/src/grcov.ts
+++ b/src/grcov.ts
@@ -111,34 +111,34 @@ export class Grcov {
             args.push(config.user.prefixDir);
         }
 
-        if (config.user.excl_br_line) {
+        if (config.user.exclBrLine) {
             args.push('--excl-br-line');
-            args.push(config.user.excl_br_line);
+            args.push(config.user.exclBrLine);
         }
 
-        if (config.user.excl_br_start) {
+        if (config.user.exclBrStart) {
             args.push('--excl-br-start');
-            args.push(config.user.excl_br_start);
+            args.push(config.user.exclBrStart);
         }
 
-        if (config.user.excl_br_stop) {
+        if (config.user.exclBrStop) {
             args.push('--excl-br-stop');
-            args.push(config.user.excl_br_stop);
+            args.push(config.user.exclBrStop);
         }
 
-        if (config.user.excl_line) {
+        if (config.user.exclLine) {
             args.push('--excl-line');
-            args.push(config.user.excl_line);
+            args.push(config.user.exclLine);
         }
 
-        if (config.user.excl_start) {
+        if (config.user.exclStart) {
             args.push('--excl-start');
-            args.push(config.user.excl_start);
+            args.push(config.user.exclStart);
         }
 
-        if (config.user.excl_stop) {
+        if (config.user.exclStop) {
             args.push('--excl-stop');
-            args.push(config.user.excl_stop);
+            args.push(config.user.exclStop);
         }
 
         // TODO:

--- a/src/grcov.ts
+++ b/src/grcov.ts
@@ -111,6 +111,36 @@ export class Grcov {
             args.push(config.user.prefixDir);
         }
 
+        if (config.user.excl_br_line) {
+            args.push('--excl-br-line');
+            args.push(config.user.excl_br_line);
+        }
+
+        if (config.user.excl_br_start) {
+            args.push('--excl-br-start');
+            args.push(config.user.excl_br_start);
+        }
+
+        if (config.user.excl_br_stop) {
+            args.push('--excl-br-stop');
+            args.push(config.user.excl_br_stop);
+        }
+
+        if (config.user.excl_line) {
+            args.push('--excl-line');
+            args.push(config.user.excl_line);
+        }
+
+        if (config.user.excl_start) {
+            args.push('--excl-start');
+            args.push(config.user.excl_start);
+        }
+
+        if (config.user.excl_stop) {
+            args.push('--excl-stop');
+            args.push(config.user.excl_stop);
+        }
+
         // TODO:
         // args.push('--service-job-number');
         // args.push('');


### PR DESCRIPTION
Added ability to provide the following parameters via config:

```
        --excl-br-line <regex>
            Lines in covered files containing this marker will be excluded from branch coverage.

        --excl-br-start <regex>
            Marks the end of a section excluded from branch coverage. The current line is part of this section.

        --excl-br-stop <regex>
            Marks the end of a section excluded from branch coverage. The current line is part of this section.

        --excl-line <regex>
            Lines in covered files containing this marker will be excluded.

        --excl-start <regex>
            Marks the beginning of an excluded section. The current line is part of this section.

        --excl-stop <regex>
            Marks the end of an excluded section. The current line is part of this section.

```

https://github.com/actions-rs/grcov/issues/80